### PR TITLE
Use dark foreground color in light mode for button in list

### DIFF
--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -10,6 +10,9 @@ import SwiftUI
 
 /// A simple button to be used in a `List` with default padding and image size
 struct ListButton: View {
+    
+    @Environment(\.colorScheme) var colorScheme: ColorScheme
+
     var image: Image
     var text: String
     var action: () -> Void
@@ -24,6 +27,6 @@ struct ListButton: View {
                 #endif
             }
         }
-        .foregroundColor(.white)
+        .foregroundColor(colorScheme == .light ? .black : .white)
     }
 }

--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -10,9 +10,6 @@ import SwiftUI
 
 /// A simple button to be used in a `List` with default padding and image size
 struct ListButton: View {
-    
-    @Environment(\.colorScheme) var colorScheme: ColorScheme
-
     var image: Image
     var text: String
     var action: () -> Void

--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -27,6 +27,6 @@ struct ListButton: View {
                 #endif
             }
         }
-        .foregroundColor(colorScheme == .light ? .black : .white)
+        .foregroundColor(.primary)
     }
 }


### PR DESCRIPTION
In light mode the button in the list is white (not visible).

![IMG_7D6A0097DF30-1](https://user-images.githubusercontent.com/11810704/76702831-58a8ae80-66cd-11ea-82ba-9b4307414c7b.jpeg)

I changed the color to black in light mode.