### PR TITLE
Add color to token Id

### DIFF
--- a/Shared/Reusable/Token.swift
+++ b/Shared/Reusable/Token.swift
@@ -18,7 +18,7 @@ struct Token: View, Identifiable {
     var text: String
     
     var id: String {
-        text
+        "text\(color)"
     }
     
     var body: some View {


### PR DESCRIPTION
This solves issue #3.

The problem was that the Id of the token is just the text. So if two tokens had the same text, say "1". Then they could be recycled wrong. This adds the color to id so that it can handle the same number more than one time.

GREAT APP by the way. Love the open source project ♥️