### PR TITLE
Minor adjusts to fix the Refresh Data button on watchOS

### DIFF
--- a/Shared/RegionList.swift
+++ b/Shared/RegionList.swift
@@ -67,7 +67,8 @@ struct RegionList: View {
 }
 
 struct CountryList_Previews: PreviewProvider {
+    @State static var isRefreshAlertPresented = false
     static var previews: some View {
-        RegionList(isRefreshAlertPresented: .constant(false))
+        RegionList(isRefreshAlertPresented: $isRefreshAlertPresented)
     }
 }

--- a/Shared/RegionList.swift
+++ b/Shared/RegionList.swift
@@ -67,8 +67,7 @@ struct RegionList: View {
 }
 
 struct CountryList_Previews: PreviewProvider {
-    @State static var isRefreshAlertPresented = false
     static var previews: some View {
-        RegionList(isRefreshAlertPresented: $isRefreshAlertPresented)
+        RegionList(isRefreshAlertPresented: .constant(false))
     }
 }

--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -12,18 +12,29 @@ import SwiftUI
 struct ListButton: View {
     var image: Image
     var text: String
-    var action: () -> Void
+    var action: () -> Void = {}
     
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
-                #if os(iOS)
-                HStack { image.font(.system(size: 20)) }
-                    .frame(width: 30)
+                image.font(.system(size: 20))
+                
                 Text(text)
-                #endif
             }
         }
         .foregroundColor(.primary)
     }
 }
+
+#if DEBUG
+
+struct ListButton_Previews: PreviewProvider {
+    static var previews: some View {
+        ListButton(
+            image: Images.refresh,
+            text: "Refresh Data"
+        )
+    }
+}
+
+#endif

--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -12,13 +12,13 @@ import SwiftUI
 struct ListButton: View {
     var image: Image
     var text: String
-    var action: () -> Void = {}
+    var action: () -> Void
     
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
-                image.font(.system(size: 20))
-                
+                HStack { image.font(.system(size: 20)) }
+                    .frame(width: 30)
                 Text(text)
             }
         }
@@ -32,7 +32,8 @@ struct ListButton_Previews: PreviewProvider {
     static var previews: some View {
         ListButton(
             image: Images.refresh,
-            text: "Refresh Data"
+            text: "Refresh Data",
+            action: {}
         )
     }
 }

--- a/Shared/Reusable/ListButton.swift
+++ b/Shared/Reusable/ListButton.swift
@@ -25,17 +25,3 @@ struct ListButton: View {
         .foregroundColor(.primary)
     }
 }
-
-#if DEBUG
-
-struct ListButton_Previews: PreviewProvider {
-    static var previews: some View {
-        ListButton(
-            image: Images.refresh,
-            text: "Refresh Data",
-            action: {}
-        )
-    }
-}
-
-#endif


### PR DESCRIPTION
Hi @julianschiavo,

first of all, congratulations to you and your project, you are doing such an amazing job sharing these numbers out there to help people understand how hard is the situation. 

Running your project on my iPhone and Watch, I saw a small thing and I'm here to send you a small contribution, but I'm sure it will help. 

I made a small tweak in the ListButton to fix the presentation on the watchOS.

From this:
![Simulator Screen Shot - Apple Watch Series 5 - 44mm - 2020-03-16 at 19 53 57](https://user-images.githubusercontent.com/83694/76791069-5ffcb480-67c0-11ea-9e5c-9f564e4c723e.png)

To this:
![Simulator Screen Shot - Apple Watch Series 5 - 44mm - 2020-03-16 at 19 53 07](https://user-images.githubusercontent.com/83694/76791081-67bc5900-67c0-11ea-85a8-a3bd6900ff32.png)

I hope this change would help!